### PR TITLE
Replace %{?systemd_requires} with%{?systemd_ordering}

### DIFF
--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /go/src/app
 RUN make miniflux
 
 FROM rockylinux:9
-RUN dnf install -y rpm-build systemd
+RUN dnf install --setopt=install_weak_deps=False -y rpm-build systemd-rpm-macros
 RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 RUN echo "%_topdir /root/rpmbuild" >> .rpmmacros
 COPY --from=build /go/src/app/miniflux /root/rpmbuild/SOURCES/miniflux

--- a/packaging/rpm/miniflux.spec
+++ b/packaging/rpm/miniflux.spec
@@ -16,8 +16,7 @@ BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch: x86_64
 Requires(pre): shadow-utils
 
-%{?systemd_requires}
-BuildRequires: systemd
+%{?systemd_ordering}
 
 AutoReqProv: no
 


### PR DESCRIPTION
As said [in the documentation](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_dependencies_on_the_systemd_package):

> If the package wants to use systemd tools if they are available, but does not
want to declare a dependency, then the %{?systemd_ordering} macro MAY be used as a weaker form of %{?systemd_requires} that only declares an ordering during an RPM transaction.

See https://github.com/systemd/systemd/commit/2424b6bd716f0c1c3bf3406b1fd1a16ba1b6a556 and https://pagure.io/packaging-committee/issue/644 for more information.