### PR TITLE
perf(template): significantly reduce memory consumption

### DIFF
--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -55,7 +55,6 @@ func (e *Engine) ParseTemplates() error {
 		}
 		commonTemplateContents.Write(fileData)
 	}
-
 	dirEntries, err = viewTemplateFiles.ReadDir("templates/views")
 	if err != nil {
 		return err
@@ -86,15 +85,10 @@ func (e *Engine) ParseTemplates() error {
 
 	for _, dirEntry := range dirEntries {
 		templateName := dirEntry.Name()
-		fileData, err := standaloneTemplateFiles.ReadFile("templates/standalone/" + dirEntry.Name())
-		if err != nil {
-			return err
-		}
-
 		slog.Debug("Parsing template",
 			slog.String("template_name", templateName),
 		)
-		e.templates[templateName] = template.Must(template.New("base").Funcs(e.funcMap.Map()).Parse(string(fileData)))
+		e.templates[templateName] = template.Must(template.New("base").Funcs(e.funcMap.Map()).ParseFS(standaloneTemplateFiles, "templates/standalone/"+dirEntry.Name()))
 	}
 
 	return nil
@@ -130,8 +124,7 @@ func (e *Engine) Render(name string, data map[string]interface{}) []byte {
 	})
 
 	var b bytes.Buffer
-	err := tpl.ExecuteTemplate(&b, "base", data)
-	if err != nil {
+	if err := tpl.ExecuteTemplate(&b, "base", data); err != nil {
 		panic(err)
 	}
 

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -1,0 +1,11 @@
+package template // import "miniflux.app/v2/internal/template"
+
+import (
+	"testing"
+)
+
+func TestParseTemplates(t *testing.T) {
+	if err := NewEngine(nil).ParseTemplates(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Use ParseFS to directly parse the embedded template data, instead of manually reading it and then using Parse.

Have you followed these guidelines?

- [ ] I have tested my changes
- [ ] There are no breaking changes
- [ ] I have thoroughly tested my changes and verified there are no regressions
- [ ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [ ] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
